### PR TITLE
mod puppi version to current

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
   ],
 
   "dependencies": [
-    { "name": "example42/puppi", "version_requirement": ">= 2.3.0" },
+    { "name": "example42/puppi", "version_requirement": ">= 2.1.14" },
     { "name": "alup/rbenv", "version_requirement": ">= 1.2.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.9.0" },
     { "name": "puppetlabs/mysql", "version_requirement": ">= 3.6.1" },


### PR DESCRIPTION
This change in response to issue #2, as well as my need to manage us of this module under librarian-puppet.  The Puppi version you reference does not appear to exist yet.  It's not much of a change, but I thought you might want to pull it in.
